### PR TITLE
ac - added endpoint to retrieve individual review by id

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
@@ -142,7 +142,6 @@ public class ReviewController extends ApiController {
             throw new AccessDeniedException("You don't have permission to view this review");
         }
         
-        log.info("Retrieved review with id {}", id);
         return review;
     }
 

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
@@ -125,6 +125,27 @@ public class ReviewController extends ApiController {
         return review;
     }
 
+    @Operation(summary = "Get a single review by id")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/get")
+    public Review getReview(@Parameter(name = "id") @RequestParam Long id) {
+        log.info("Attempting to get review with id {}", id);
+        
+        Review review = reviewRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Review.class, id));
+        
+        // Check if user has permission to view this review
+        User currentUser = getCurrentUser().getUser();
+        
+        // User can view their own reviews or if they are an admin
+        if (currentUser.getId() != review.getReviewer().getId() && !currentUser.getAdmin()) {
+            throw new AccessDeniedException("You don't have permission to view this review");
+        }
+        
+        log.info("Retrieved review with id {}", id);
+        return review;
+    }
+
     /**
      * This method allows a user to get a list of reviews that they have previously made.
      * Only user can only get a list of their own reviews, and you cant request another persons reviews


### PR DESCRIPTION
In this PR, we added an endpoint that is able to retrieve an individual review by id. Since the moderator role isn't implemented yet, we can add that part after. But for now this closes #23 

Link to deployment: https://dining-dev-andrewc512.dokku-10.cs.ucsb.edu/

This is what it looks like on swagger.
<img width="863" alt="image" src="https://github.com/user-attachments/assets/82aecc67-89d0-4a73-8643-6e6f2208e7d6" />
