### PR TITLE
Created Placeholder Page for Reviews

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -68,7 +68,8 @@ function App() {
             />
             <Route
               path="/placeholder/reviews"
-              element={<PlaceholderReviewsIndexPage />} />
+              element={<PlaceholderReviewsIndexPage />}
+            />
           </>
         )}
         <>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -62,6 +62,10 @@ function App() {
               path="/placeholder/create"
               element={<PlaceholderCreatePage />}
             />
+          </>
+        )}
+        {hasRole(currentUser, "ROLE_ADMIN") && (
+          <>
             <Route
               path="/reviews/:itemid"
               element={<PlaceholderReviewsPage />}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -64,7 +64,7 @@ function App() {
             />
           </>
         )}
-        {hasRole(currentUser, "ROLE_ADMIN") && (
+        {hasRole(currentUser, "ROLE_USER") && (
           <>
             <Route
               path="/reviews/:itemid"

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,9 @@ import AdminUsersPage from "main/pages/AdminUsersPage";
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
+import PlaceholderReviewsPage from "main/pages/Placeholder/PlaceholderReviewsPage";
+
+import PlaceholderReviewsIndexPage from "main/pages/Reviews/PlaceholderReviewsIndexPage";
 
 import MyReviewsIndexPage from "main/pages/MyReviews/MyReviewsIndexPage";
 
@@ -59,6 +62,13 @@ function App() {
               path="/placeholder/create"
               element={<PlaceholderCreatePage />}
             />
+            <Route
+              path="/reviews/:itemid"
+              element={<PlaceholderReviewsPage />}
+            />
+            <Route
+              path="/placeholder/reviews"
+              element={<PlaceholderReviewsIndexPage />} />
           </>
         )}
         <>

--- a/frontend/src/fixtures/menuItemFixtures.js
+++ b/frontend/src/fixtures/menuItemFixtures.js
@@ -1,28 +1,34 @@
 const menuItemFixtures = {
   oneMenuItem: [
     {
+      id: 1,
       name: "Oatmeal (vgn)",
       station: "Grill (Cafe)",
     },
   ],
   fiveMenuItems: [
     {
+      id: 1,
       name: "Oatmeal (vgn)",
       station: "Grill (Cafe)",
     },
     {
+      id: 2,
       name: "Blintz with Strawberry Compote (v)",
       station: "Grill (Cafe)",
     },
     {
+      id: 3,
       name: "Cage Free Scrambled Eggs (v)",
       station: "Grill (Cafe)",
     },
     {
+      id: 4,
       name: "Cage Free Scrambled Egg Whites (v)",
       station: "Grill (Cafe)",
     },
     {
+      id: 5,
       name: "Sliced Potato with Onions (vgn)",
       station: "Grill (Cafe)",
     },

--- a/frontend/src/main/components/MenuItem/MenuItemTable.js
+++ b/frontend/src/main/components/MenuItem/MenuItemTable.js
@@ -1,11 +1,15 @@
+import React from "react";
 import OurTable, { ButtonColumn } from "../OurTable";
 import { hasRole } from "../../utils/currentUser";
+import { Link } from "react-router-dom";
 
 export default function MenuItemTable({ menuItems, currentUser }) {
   const testid = "MenuItemTable";
+
   const reviewCallback = async (_cell) => {
     alert("Reviews coming soon!");
   };
+
   const columns = [
     {
       Header: "Item Name",
@@ -16,9 +20,17 @@ export default function MenuItemTable({ menuItems, currentUser }) {
       accessor: "station",
     },
   ];
+
+  const reviewLinkColumn = {
+    Header: "Reviews",
+    accessor: "id",
+    Cell: ({ value }) => <Link to={`/reviews/${value}`}>View</Link>,
+  };
+
   if (hasRole(currentUser, "ROLE_USER")) {
     columns.push(
       ButtonColumn("Review Item", "warning", reviewCallback, testid),
+      reviewLinkColumn,
     );
   }
 

--- a/frontend/src/main/components/MenuItem/MenuItemTable.js
+++ b/frontend/src/main/components/MenuItem/MenuItemTable.js
@@ -19,18 +19,18 @@ export default function MenuItemTable({ menuItems, currentUser }) {
       Header: "Station",
       accessor: "station",
     },
+    {
+      Header: () => (
+        <span data-testid="MenuItemTable-header-Reviews">Reviews</span>
+      ),
+      accessor: "id",
+      Cell: ({ value }) => <Link to={`/reviews/${value}`}>View</Link>,
+    },
   ];
-
-  const reviewLinkColumn = {
-    Header: "Reviews",
-    accessor: "id",
-    Cell: ({ value }) => <Link to={`/reviews/${value}`}>View</Link>,
-  };
 
   if (hasRole(currentUser, "ROLE_USER")) {
     columns.push(
       ButtonColumn("Review Item", "warning", reviewCallback, testid),
-      reviewLinkColumn,
     );
   }
 

--- a/frontend/src/main/pages/Placeholder/PlaceholderIndexPage.js
+++ b/frontend/src/main/pages/Placeholder/PlaceholderIndexPage.js
@@ -12,6 +12,9 @@ export default function PlaceholderIndexPage() {
         <p>
           <a href="/placeholder/edit/1">Edit</a>
         </p>
+        <p>
+          <a href="/placeholder/reviews">Reviews</a>
+        </p>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/Placeholder/PlaceholderReviewsPage.js
+++ b/frontend/src/main/pages/Placeholder/PlaceholderReviewsPage.js
@@ -1,0 +1,15 @@
+import { useParams } from "react-router-dom";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function PlaceholderReviewsPage() {
+  const { itemid } = useParams();
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Reviews for Menu Item {itemid}</h1>
+        <p>Coming Soon!</p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/Reviews/PlaceholderReviewsIndexPage.js
+++ b/frontend/src/main/pages/Reviews/PlaceholderReviewsIndexPage.js
@@ -1,0 +1,35 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { menuItemFixtures } from "fixtures/menuItemFixtures";
+import { Link } from "react-router-dom";
+
+export default function PlaceholderReviewsIndexPage() {
+  const menuItems = menuItemFixtures.fiveMenuItems;
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Reviews Index Page</h1>
+        <table className="table table-bordered table-striped table-hover">
+          <thead>
+            <tr>
+              <th>Item Name</th>
+              <th>Station</th>
+              <th>Link to Reviews</th>
+            </tr>
+          </thead>
+          <tbody>
+            {menuItems.map((item) => (
+              <tr key={item.id}>
+                <td>{item.name}</td>
+                <td>{item.station}</td>
+                <td>
+                  <Link to={`/reviews/${item.id}`}>View</Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
+++ b/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
@@ -8,6 +8,7 @@ import {
   currentUserFixtures,
 } from "../../../fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "../../../fixtures/systemInfoFixtures";
+import { MemoryRouter } from "react-router-dom";
 
 describe("MenuItemTable Tests", () => {
   let axiosMock;
@@ -15,9 +16,11 @@ describe("MenuItemTable Tests", () => {
   beforeAll(() => {
     axiosMock = new AxiosMockAdapter(axios);
   });
+
   afterEach(() => {
     axiosMock.reset();
   });
+
   test("Headers appear and empty table renders correctly without buttons", async () => {
     render(
       <MenuItemTable
@@ -42,7 +45,8 @@ describe("MenuItemTable Tests", () => {
       screen.queryByTestId("MenuItemTable-cell-row-0-col-Review Item-button"),
     ).not.toBeInTheDocument();
   });
-  test("Renders 5 Menu Items Correctly correctly without buttons", async () => {
+
+  test("Renders 5 Menu Items correctly without buttons", async () => {
     let fiveMenuItems = menuItemFixtures.fiveMenuItems;
     render(
       <MenuItemTable
@@ -72,12 +76,18 @@ describe("MenuItemTable Tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
+
     render(
-      <MenuItemTable
-        menuItems={menuItemFixtures.oneMenuItem}
-        currentUser={currentUserFixtures.userOnly}
-      />,
+      <MemoryRouter>
+        {" "}
+        {/* ✅ Wrap with MemoryRouter to support <Link> */}
+        <MenuItemTable
+          menuItems={menuItemFixtures.oneMenuItem}
+          currentUser={currentUserFixtures.userOnly}
+        />
+      </MemoryRouter>,
     );
+
     let button = screen.getByTestId(
       "MenuItemTable-cell-row-0-col-Review Item-button",
     );

--- a/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
+++ b/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
@@ -35,6 +35,11 @@ describe("MenuItemTable Tests", () => {
     expect(
       screen.getByTestId("MenuItemTable-header-station"),
     ).toHaveTextContent("Station");
+
+    expect(
+      screen.getByTestId("MenuItemTable-header-Reviews"),
+    ).toHaveTextContent("Reviews");
+
     expect(
       screen.queryByTestId("MenuItemTable-row-cell-0-col-name"),
     ).not.toBeInTheDocument();

--- a/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
+++ b/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
@@ -54,10 +54,12 @@ describe("MenuItemTable Tests", () => {
   test("Renders 5 Menu Items correctly without buttons", async () => {
     let fiveMenuItems = menuItemFixtures.fiveMenuItems;
     render(
-      <MenuItemTable
-        menuItems={fiveMenuItems}
-        currentUser={currentUserFixtures.notLoggedIn}
-      />,
+      <MemoryRouter>
+        <MenuItemTable
+          menuItems={fiveMenuItems}
+          currentUser={currentUserFixtures.notLoggedIn}
+        />
+      </MemoryRouter>,
     );
 
     for (let i = 0; i < fiveMenuItems.length; i++) {

--- a/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
+++ b/frontend/src/tests/components/MenuItem/MenuItemTable.test.js
@@ -68,7 +68,7 @@ describe("MenuItemTable Tests", () => {
     }
   });
 
-  test("Buttons work correctly", async () => {
+  test("Buttons and View links work correctly", async () => {
     const mockAlert = jest.spyOn(window, "alert").mockImplementation(() => {});
     axiosMock
       .onGet("/api/currentUser")
@@ -79,8 +79,6 @@ describe("MenuItemTable Tests", () => {
 
     render(
       <MemoryRouter>
-        {" "}
-        {/* ✅ Wrap with MemoryRouter to support <Link> */}
         <MenuItemTable
           menuItems={menuItemFixtures.oneMenuItem}
           currentUser={currentUserFixtures.userOnly}
@@ -95,10 +93,13 @@ describe("MenuItemTable Tests", () => {
     expect(button).toHaveClass("btn-warning");
 
     fireEvent.click(button);
-
     await waitFor(() => {
       expect(mockAlert).toBeCalledTimes(1);
     });
     expect(mockAlert).toBeCalledWith("Reviews coming soon!");
+
+    const viewLink = screen.getByRole("link", { name: "View" });
+    expect(viewLink).toBeInTheDocument();
+    expect(viewLink).toHaveAttribute("href", "/reviews/1");
   });
 });

--- a/frontend/src/tests/pages/Placeholder/PlaceholderReviewsPage.test.js
+++ b/frontend/src/tests/pages/Placeholder/PlaceholderReviewsPage.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import PlaceholderReviewsPage from "main/pages/Reviews/PlaceholderReviewsPage";
+import PlaceholderReviewsPage from "main/pages/Placeholder/PlaceholderReviewsPage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 

--- a/frontend/src/tests/pages/Placeholder/PlaceholderReviewsPage.test.js
+++ b/frontend/src/tests/pages/Placeholder/PlaceholderReviewsPage.test.js
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import PlaceholderReviewsPage from "main/pages/Reviews/PlaceholderReviewsPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("PlaceholderReviewsPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+
+  test("Renders expected content with menu item id", async () => {
+    // arrange
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/reviews/42"]}>
+          <Routes>
+            <Route
+              path="/reviews/:itemid"
+              element={<PlaceholderReviewsPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expect(
+      await screen.findByText("Reviews for Menu Item 42"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Coming Soon!")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/Reviews/PlaceholderReviewsIndexPage.test.js
+++ b/frontend/src/tests/pages/Reviews/PlaceholderReviewsIndexPage.test.js
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import PlaceholderReviewsIndexPage from "main/pages/Reviews/PlaceholderReviewsIndexPage";
+import { MemoryRouter } from "react-router-dom";
+
+describe("PlaceholderReviewsIndexPage", () => {
+  test("renders menu items and review links correctly", () => {
+    render(
+      <MemoryRouter>
+        <PlaceholderReviewsIndexPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Reviews Index Page")).toBeInTheDocument();
+    expect(screen.getByText("Oatmeal (vgn)")).toBeInTheDocument();
+
+    const link = screen.getByRole("link", { name: "View" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/reviews/1");
+  });
+});

--- a/frontend/src/tests/pages/Reviews/PlaceholderReviewsIndexPage.test.js
+++ b/frontend/src/tests/pages/Reviews/PlaceholderReviewsIndexPage.test.js
@@ -1,20 +1,26 @@
 import { render, screen } from "@testing-library/react";
 import PlaceholderReviewsIndexPage from "main/pages/Reviews/PlaceholderReviewsIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
 describe("PlaceholderReviewsIndexPage", () => {
+  const queryClient = new QueryClient();
+
   test("renders menu items and review links correctly", () => {
     render(
-      <MemoryRouter>
-        <PlaceholderReviewsIndexPage />
-      </MemoryRouter>,
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PlaceholderReviewsIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
     );
 
     expect(screen.getByText("Reviews Index Page")).toBeInTheDocument();
     expect(screen.getByText("Oatmeal (vgn)")).toBeInTheDocument();
 
-    const link = screen.getByRole("link", { name: "View" });
-    expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute("href", "/reviews/1");
+    const links = screen.getAllByRole("link", { name: "View" });
+    expect(links.length).toBe(5);
+
+    expect(links[0]).toHaveAttribute("href", "/reviews/1");
   });
 });

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -46,7 +46,6 @@ describe("utils/currentUser tests", () => {
       expect(queryState).toBeDefined();
 
       queryClient.clear();
-
       await waitFor(() => expect(console.error).toHaveBeenCalled());
       const errorMessage = console.error.mock.calls[0][0];
       expect(errorMessage).toMatch(/Error invoking axios.get:/);
@@ -64,7 +63,7 @@ describe("utils/currentUser tests", () => {
       const axiosMock = new AxiosMockAdapter(axios);
       axiosMock
         .onGet("/api/currentUser")
-        .reply(200, apiCurrentUserFixtures.userOnly);
+        .reply(200, currentUserFixtures.userOnly.root);
       axiosMock
         .onGet("/api/systemInfo")
         .reply(200, systemInfoFixtures.showingNeither);
@@ -134,6 +133,7 @@ describe("utils/currentUser tests", () => {
       queryClient.clear();
     });
   });
+
   describe("useLogout tests", () => {
     test("useLogout", async () => {
       const queryClient = new QueryClient();
@@ -157,8 +157,8 @@ describe("utils/currentUser tests", () => {
         expect(useNavigate).toHaveBeenCalled();
         result.current.mutate();
       });
-      await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith("/"));
 
+      await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith("/"));
       await waitFor(() =>
         expect(resetQueriesSpy).toHaveBeenCalledWith("current user", {
           exact: true,
@@ -168,6 +168,7 @@ describe("utils/currentUser tests", () => {
       queryClient.clear();
     });
   });
+
   describe("hasRole tests", () => {
     test('hasRole(x,"ROLE_ADMIN") return falsy when currentUser ill-defined', async () => {
       expect(hasRole(null, "ROLE_ADMIN")).toBeFalsy();
@@ -235,6 +236,5 @@ describe("utils/currentUser tests", () => {
         hasRole({ data: { root: { rolesList: [] } } }, "ROLE_USER"),
       ).toBeFalsy();
     });
-    expect(hasRole({ root: { rolesList: null } })).toBeFalsy();
   });
 });


### PR DESCRIPTION
merge before #47 #43 #35 #34 #48
closes #12 
frontend now has a placeholder page for reviews. shows all menu items and user can click on reviews and see all the reviews. link at reviews/itemid
<img width="539" alt="w" src="https://github.com/user-attachments/assets/9e48d4cb-c73f-4df5-b47a-39ba34b2b69d" />
<img width="1061" alt="ww" src="https://github.com/user-attachments/assets/07a65857-4c81-4e63-85e5-a26efebb2ee6" />
<img width="505" alt="www" src="https://github.com/user-attachments/assets/ffd32aa9-6059-4331-ae6e-9f396133e19b" />
dokku deployment: https://proj-dev-junjiel123.dokku-10.cs.ucsb.edu/