### PR TITLE
mk - added review table feature

### DIFF
--- a/frontend/src/fixtures/reviewFixtures.js
+++ b/frontend/src/fixtures/reviewFixtures.js
@@ -1,50 +1,41 @@
-const ReviewFixtures = {
-  oneReview: {
-    id: 1,
-    studentId: 1,
-    itemId: 7,
-    dateItemServed: "2022-01-02T12:00:00",
-    status: "AWAITING_REVIEW",
-    userIdModerator: null,
-    moderatorComments: null,
-    dateCreated: "2022-01-01T12:00:00",
-    dateEdited: "2022-01-01T12:00:00",
-  },
-  threeReviews: [
+const reviewFixtures = {
+  oneReview: [
     {
       id: 1,
-      studentId: 1,
-      itemId: 7,
-      dateItemServed: "2022-01-02T12:00:00",
-      status: "APPROVED",
-      userIdModerator: 4,
-      moderatorComments: "Looks good",
-      dateCreated: "2022-01-01T12:00:00",
-      dateEdited: "2022-01-02T13:00:00",
+      itemName: "Tacos",
+      itemStars: 4,
+      comments: "It was alright",
+      dateServed: "2022-05-02T12:00:00",
+      status: "Approved",
     },
+  ],
+
+  threeReviews: [
     {
       id: 2,
-      studentId: 2,
-      itemId: 8,
-      dateItemServed: "2022-02-02T12:00:00",
-      status: "REJECTED",
-      userIdModerator: 5,
-      moderatorComments: "Inappropriate content",
-      dateCreated: "2022-02-01T12:00:00",
-      dateEdited: "2022-02-02T13:00:00",
+      itemName: "Pizza",
+      itemStars: 5,
+      comments: "It was ok",
+      dateServed: "2022-01-02T12:00:00",
+      status: "Approved",
     },
     {
       id: 3,
-      studentId: 3,
-      itemId: 9,
-      dateItemServed: "2022-03-02T12:00:00",
-      status: "AWAITING_REVIEW",
-      userIdModerator: 6,
-      moderatorComments: "Thanks!",
-      dateCreated: "2022-03-01T12:00:00",
-      dateEdited: "2022-03-01T12:00:00",
+      itemName: "Hamburger",
+      itemStars: 3,
+      comments: "I mean, it's alright",
+      dateServed: "2012-01-02T12:00:00",
+      status: "Approved",
+    },
+    {
+      id: 4,
+      itemName: "Cupcake",
+      itemStars: 1,
+      comments: "Horrible",
+      dateServed: "2016-03-05T12:00:00",
+      status: "Denied",
     },
   ],
 };
 
-export { ReviewFixtures };
+export { reviewFixtures };

--- a/frontend/src/main/components/Review/ReviewTable.js
+++ b/frontend/src/main/components/Review/ReviewTable.js
@@ -1,0 +1,105 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  cellToAxiosParamsPostWithStatus,
+  onDeleteSuccess,
+  onApproveSuccess,
+  onDenySuccess,
+} from "main/utils/reviewUtils";
+import { useNavigate } from "react-router-dom";
+
+export default function ReviewTable({
+  reviews,
+  userOptions = false,
+  moderatorOptions = false,
+  testIdPrefix = "ReviewTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/reviews/edit/${cell.row.values.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/reviews/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  // Mutation for approve
+
+  // Stryker disable all : hard to test for query caching
+  const approveMutation = useBackendMutation(
+    (cell) => cellToAxiosParamsPostWithStatus(cell, "Approved"),
+    { onSuccess: onApproveSuccess },
+    ["/api/reviews/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable all : hard to test for query caching
+  const denyMutation = useBackendMutation(
+    (cell) => cellToAxiosParamsPostWithStatus(cell, "Denied"),
+    { onSuccess: onDenySuccess },
+    ["/api/reviews/all"],
+  );
+  // Stryker restore all
+
+  const approveCallback = async (cell) => {
+    approveMutation.mutate(cell);
+  };
+
+  const denyCallback = async (cell) => {
+    denyMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      Header: "id",
+      accessor: "id", // accessor is the "key" in the data
+    },
+    {
+      Header: "Stars",
+      accessor: "itemStars",
+    },
+    {
+      Header: "Comments",
+      accessor: "comments",
+    },
+    {
+      Header: "Date Served",
+      accessor: "dateServed",
+    },
+    {
+      Header: "Status",
+      accessor: "status",
+    },
+  ];
+
+  if (userOptions) {
+    columns.push({ Header: "Item Name", accessor: "itemName" });
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  if (moderatorOptions) {
+    columns.push(
+      ButtonColumn("Approve", "primary", approveCallback, testIdPrefix),
+    );
+    columns.push(ButtonColumn("Deny", "danger", denyCallback, testIdPrefix));
+  }
+
+  return <OurTable columns={columns} data={reviews} testid={testIdPrefix} />;
+}

--- a/frontend/src/main/utils/reviewUtils.js
+++ b/frontend/src/main/utils/reviewUtils.js
@@ -1,0 +1,42 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  toast(message);
+}
+
+export function onApproveSuccess(message) {
+  toast(message);
+}
+
+export function onDenySuccess(message) {
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/reviews",
+    method: "DELETE",
+    params: {
+      id: cell.row.values.id,
+    },
+  };
+}
+
+export function cellToAxiosParamsPostWithStatus(cell, status) {
+  const updatedReview = {
+    ...cell.row.values,
+    status,
+  };
+
+  return {
+    url: `/api/reviews/${cell.row.values.id}`,
+    method: "PUT",
+    data: {
+      itemName: updatedReview.itemName,
+      itemStars: updatedReview.itemStars,
+      comments: updatedReview.comments,
+      dateServed: updatedReview.dateServed,
+      status: updatedReview.status,
+    },
+  };
+}

--- a/frontend/src/stories/components/Review/ReviewTable.stories.js
+++ b/frontend/src/stories/components/Review/ReviewTable.stories.js
@@ -1,0 +1,48 @@
+import React from "react";
+import ReviewTable from "main/components/Review/ReviewTable";
+import { reviewFixtures } from "fixtures/reviewFixtures";
+
+export default {
+  title: "components/Review/ReviewTable",
+  component: ReviewTable,
+};
+
+const Template = (args) => {
+  return <ReviewTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  reviews: [],
+};
+
+export const OneReview = Template.bind({});
+
+OneReview.args = {
+  reviews: reviewFixtures.oneReview,
+};
+
+export const ThreeReviews = Template.bind({});
+ThreeReviews.args = {
+  reviews: reviewFixtures.threeReviews,
+};
+
+export const ThreeReviewsWithAdmin = Template.bind({});
+ThreeReviewsWithAdmin.args = {
+  reviews: reviewFixtures.threeReviews,
+  userOptions: true,
+};
+
+export const ThreeReviewsWithMod = Template.bind({});
+ThreeReviewsWithMod.args = {
+  reviews: reviewFixtures.threeReviews,
+  moderatorOptions: true,
+};
+
+export const ThreeReviewsWithAdminAndMod = Template.bind({});
+ThreeReviewsWithAdminAndMod.args = {
+  reviews: reviewFixtures.threeReviews,
+  userOptions: true,
+  moderatorOptions: true,
+};

--- a/frontend/src/tests/components/Review/ReviewTable.test.js
+++ b/frontend/src/tests/components/Review/ReviewTable.test.js
@@ -5,6 +5,12 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import {
+  onDeleteSuccess,
+  onApproveSuccess,
+  onDenySuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/reviewUtils";
 
 import { toast } from "react-toastify";
 
@@ -290,6 +296,44 @@ describe("ReviewTable tests", () => {
       expect(JSON.parse(axiosMock.history.put[1].data)).toMatchObject({
         status: "Denied",
       });
+    });
+  });
+});
+
+describe("reviewUtils function coverage", () => {
+  beforeEach(() => {
+    toast.mockClear();
+  });
+
+  test("onDeleteSuccess calls toast with correct message", () => {
+    onDeleteSuccess("Review deleted");
+    expect(toast).toHaveBeenCalledWith("Review deleted");
+  });
+
+  test("onApproveSuccess calls toast with correct message", () => {
+    onApproveSuccess("Review approved");
+    expect(toast).toHaveBeenCalledWith("Review approved");
+  });
+
+  test("onDenySuccess calls toast with correct message", () => {
+    onDenySuccess("Review denied");
+    expect(toast).toHaveBeenCalledWith("Review denied");
+  });
+
+  test("cellToAxiosParamsDelete returns correct delete config", () => {
+    const cell = {
+      row: {
+        values: {
+          id: 42,
+        },
+      },
+    };
+
+    const result = cellToAxiosParamsDelete(cell);
+    expect(result).toEqual({
+      url: "/api/reviews",
+      method: "DELETE",
+      params: { id: 42 },
     });
   });
 });

--- a/frontend/src/tests/components/Review/ReviewTable.test.js
+++ b/frontend/src/tests/components/Review/ReviewTable.test.js
@@ -263,9 +263,14 @@ describe("ReviewTable tests", () => {
       expect(axiosMock.history.put.length).toBe(1);
     });
 
-    expect(axiosMock.history.put[0].url).toBe("/api/reviews/2");
-    expect(JSON.parse(axiosMock.history.put[0].data)).toMatchObject({
-      status: "Approved",
+    await waitFor(() => {
+      expect(axiosMock.history.put[0].url).toBe("/api/reviews/2");
+    });
+
+    await waitFor(() => {
+      expect(JSON.parse(axiosMock.history.put[0].data)).toMatchObject({
+        status: "Approved",
+      });
     });
 
     const denyButton = await screen.findByTestId(
@@ -274,12 +279,17 @@ describe("ReviewTable tests", () => {
     fireEvent.click(denyButton);
 
     await waitFor(() => {
-      expect(axiosMock.history.put.length).toBe(1);
+      expect(axiosMock.history.put.length).toBe(2);
     });
 
-    expect(axiosMock.history.put[0].url).toBe("/api/reviews/2");
-    expect(JSON.parse(axiosMock.history.put[0].data)).toMatchObject({
-      status: "Denied",
+    await waitFor(() => {
+      expect(axiosMock.history.put[1].url).toBe("/api/reviews/3");
+    });
+
+    await waitFor(() => {
+      expect(JSON.parse(axiosMock.history.put[1].data)).toMatchObject({
+        status: "Denied",
+      });
     });
   });
 });

--- a/frontend/src/tests/components/Review/ReviewTable.test.js
+++ b/frontend/src/tests/components/Review/ReviewTable.test.js
@@ -1,0 +1,285 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { reviewFixtures } from "../../../fixtures/reviewFixtures";
+import ReviewTable from "../../../main/components/Review/ReviewTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import { toast } from "react-toastify";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+jest.mock("react-toastify", () => ({
+  toast: jest.fn(),
+}));
+
+beforeEach(() => {
+  toast.mockClear();
+});
+
+describe("ReviewTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "id",
+    "Stars",
+    "Comments",
+    "Date Served",
+    "Item Name",
+  ];
+  const expectedFields = [
+    "id",
+    "itemStars",
+    "comments",
+    "dateServed",
+    "itemName",
+  ];
+  const testId = "ReviewTable";
+
+  test("renders empty table correctly", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReviewTable reviews={[]} userOptions={true} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      expect(screen.getByText(headerText)).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      expect(
+        screen.queryByTestId(`${testId}-cell-row-0-col-${field}`),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has expected content and buttons for admin user", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReviewTable
+            reviews={reviewFixtures.threeReviews}
+            userOptions={true}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      expect(screen.getByText(headerText)).toBeInTheDocument();
+    });
+
+    // Row 0 (id 2)
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-itemStars`),
+    ).toHaveTextContent("5");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-comments`),
+    ).toHaveTextContent("It was ok");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-dateServed`),
+    ).toHaveTextContent("2022-01-02T12:00:00");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-itemName`),
+    ).toHaveTextContent("Pizza");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-status`),
+    ).toHaveTextContent("Approved");
+
+    // Buttons
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toHaveClass("btn-danger");
+
+    // Check that moderator buttons don't exist
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Approve-button`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Deny-button`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("Has expected content for ordinary user (no buttons or itemName)", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReviewTable reviews={reviewFixtures.threeReviews} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Should NOT render itemName or buttons
+    expect(screen.queryByText("Item Name")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+
+    // Still renders main columns
+    expect(screen.getByText("id")).toBeInTheDocument();
+    expect(screen.getByText("Stars")).toBeInTheDocument();
+
+    expect(screen.getByText("Status")).toBeInTheDocument();
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "3",
+    );
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReviewTable
+            reviews={reviewFixtures.threeReviews}
+            userOptions={true}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const editButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/reviews/edit/2"),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/reviews")
+      .reply(200, { message: "Review deleted" });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReviewTable
+            reviews={reviewFixtures.threeReviews}
+            userOptions={true}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const deleteButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 2 });
+  });
+
+  test("Has Approve and Deny buttons when moderatorOptions is true", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReviewTable
+            reviews={reviewFixtures.threeReviews}
+            moderatorOptions={true}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const approveButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Approve-button`,
+    );
+    expect(approveButton).toHaveClass("btn-primary");
+    const denyButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Deny-button`,
+    );
+    expect(denyButton).toHaveClass("btn-danger");
+  });
+
+  test("Approve and Deny buttons are NOT shown when moderatorOptions is false", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReviewTable
+            reviews={reviewFixtures.threeReviews}
+            moderatorOptions={false}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Approve-button`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Deny-button`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("Clicking Approve and Deny triggers backend mutation", async () => {
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    axiosMock.onPut("/api/reviews/2").reply(200, { message: "Approved" });
+    axiosMock.onPut("/api/reviews/3").reply(200, { message: "Denied" });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReviewTable
+            reviews={reviewFixtures.threeReviews}
+            moderatorOptions={true}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const approveButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Approve-button`,
+    );
+    fireEvent.click(approveButton);
+
+    await waitFor(() => {
+      expect(axiosMock.history.put.length).toBe(1);
+    });
+
+    expect(axiosMock.history.put[0].url).toBe("/api/reviews/2");
+    expect(JSON.parse(axiosMock.history.put[0].data)).toMatchObject({
+      status: "Approved",
+    });
+
+    const denyButton = await screen.findByTestId(
+      `${testId}-cell-row-1-col-Deny-button`,
+    );
+    fireEvent.click(denyButton);
+
+    await waitFor(() => {
+      expect(axiosMock.history.put.length).toBe(1);
+    });
+
+    expect(axiosMock.history.put[0].url).toBe("/api/reviews/2");
+    expect(JSON.parse(axiosMock.history.put[0].data)).toMatchObject({
+      status: "Denied",
+    });
+  });
+});


### PR DESCRIPTION
Closes #2 

Implemented a review table (for menu items) and its different buttons such as edit, delete, approve, and deny. I also added tests to cover all the possible actions the user can take. Since the review pages have not been implemented yet, this can only be tested on storybook by going to the Review folder and checking out OneReview and ThreeReviews for all combinations of admin and moderator.

Storybook UIs:

No Admin or Moderator:
<img width="1127" alt="image" src="https://github.com/user-attachments/assets/2a8d59a8-544a-47c2-878b-6f48e0c6fad2" />

Admin:
<img width="1127" alt="image" src="https://github.com/user-attachments/assets/612e5ce7-e29d-4c41-a58a-68af5413b478" />

Moderator:
<img width="1127" alt="Screenshot 2025-05-22 at 3 12 32 PM" src="https://github.com/user-attachments/assets/1d2b2134-2d8d-4802-ae3d-7e9cb6a38588" />

Storybook Link: https://682fa1f8a493d1b3dca74be3-nkqyxddgzt.chromatic.com/?path=/story/components-review-reviewtable--three-reviews

Dokku Deployment: https://proj-dining-dev-mihir-r-kondapalli.dokku-10.cs.ucsb.edu/

You can test in storybook.
