### PR TITLE
Added Alias Approval Table to approve alias update requests

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,6 +14,7 @@ import MyReviewsIndexPage from "main/pages/MyReviews/MyReviewsIndexPage";
 import MealTimesPage from "main/pages/Meal/MealTimesPage";
 
 import Moderate from "main/pages/Moderate";
+import AliasApprovalPage from "main/pages/AliasApprovalPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -40,6 +41,17 @@ function App() {
         {(hasRole(currentUser, "ROLE_ADMIN") ||
           hasRole(currentUser, "ROLE_MODERATOR")) && (
           <Route exact path="/moderate" element={<Moderate />} />
+        )}
+        {(hasRole(currentUser, "ROLE_ADMIN") ||
+          hasRole(currentUser, "ROLE_MODERATOR")) && (
+          <>
+            <Route exact path="/moderate" element={<Moderate />} />
+            <Route
+              exact
+              path="/alias-approval"
+              element={<AliasApprovalPage />}
+            />
+          </>
         )}
         {hasRole(currentUser, "ROLE_USER") && (
           <>

--- a/frontend/src/fixtures/currentUserFixtures.js
+++ b/frontend/src/fixtures/currentUserFixtures.js
@@ -158,6 +158,7 @@ const apiCurrentUserFixtures = {
       hostedDomain: null,
       admin: false,
     },
+    roles: null,
   },
 };
 

--- a/frontend/src/main/components/AliasApprovalTable.js
+++ b/frontend/src/main/components/AliasApprovalTable.js
@@ -35,7 +35,7 @@ export default function AliasApprovalTable({ users }) {
   };
 
   const mutation = useBackendMutation(objectToAxiosParams, { onSuccess }, [
-    "alias-approval",
+    ["/api/admin/usersWithProposedAlias"],
   ]);
 
   const columns = [

--- a/frontend/src/main/components/AliasApprovalTable.js
+++ b/frontend/src/main/components/AliasApprovalTable.js
@@ -1,12 +1,22 @@
 import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
-import { useBackendMutation } from "main/utils/useBackend";
+import { useBackendMutation, useBackend } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 import { useQueryClient } from "react-query";
 
-export default function AliasApprovalTable({ users }) {
+export default function AliasApprovalTable() {
   const testid = "AliasApprovalTable";
   const queryClient = useQueryClient();
+
+  const {
+    data: users,
+    error,
+    status,
+  } = useBackend(
+    ["/api/admin/usersWithProposedAlias"],
+    { method: "GET", url: "/api/admin/usersWithProposedAlias" },
+    [],
+  );
 
   const objectToAxiosParams = (variables) => {
     if (
@@ -31,12 +41,10 @@ export default function AliasApprovalTable({ users }) {
     toast(
       `${variables.approved ? "Approved" : "Rejected"} alias: ${returnedUser.alias}`,
     );
-    queryClient.invalidateQueries("alias-approval");
+    queryClient.invalidateQueries("/api/admin/usersWithProposedAlias");
   };
 
-  const mutation = useBackendMutation(objectToAxiosParams, { onSuccess }, [
-    ["/api/admin/usersWithProposedAlias"],
-  ]);
+  const mutation = useBackendMutation(objectToAxiosParams, { onSuccess });
 
   const columns = [
     { Header: "Alias", accessor: "alias" },
@@ -50,6 +58,9 @@ export default function AliasApprovalTable({ users }) {
       mutation.mutate({ id: user.id, approved: false });
     }),
   ];
+
+  if (status === "loading") return <div>Loading...</div>;
+  if (error) return <div>Error loading aliases</div>;
 
   return <OurTable data={users} columns={columns} testid={testid} />;
 }

--- a/frontend/src/main/components/AliasApprovalTable.js
+++ b/frontend/src/main/components/AliasApprovalTable.js
@@ -1,0 +1,55 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+import { useQueryClient } from "react-query";
+
+export default function AliasApprovalTable({ users }) {
+  const testid = "AliasApprovalTable";
+  const queryClient = useQueryClient();
+
+  const objectToAxiosParams = (variables) => {
+    if (
+      !variables ||
+      typeof variables.id === "undefined" ||
+      typeof variables.approved === "undefined"
+    ) {
+      console.error("Missing id or approved in mutation variables:", variables);
+      return {};
+    }
+    return {
+      url: "/api/currentUser/updateAliasModeration",
+      method: "PUT",
+      params: {
+        id: variables.id,
+        approved: variables.approved,
+      },
+    };
+  };
+
+  const onSuccess = (returnedUser, variables) => {
+    toast(
+      `${variables.approved ? "Approved" : "Rejected"} alias: ${returnedUser.alias}`,
+    );
+    queryClient.invalidateQueries("alias-approval");
+  };
+
+  const mutation = useBackendMutation(objectToAxiosParams, { onSuccess }, [
+    "alias-approval",
+  ]);
+
+  const columns = [
+    { Header: "Alias", accessor: "alias" },
+    { Header: "Proposed Alias", accessor: "proposedAlias" },
+    ButtonColumn("Approve", "success", (cell) => {
+      const user = cell.row.original;
+      mutation.mutate({ id: user.id, approved: true });
+    }),
+    ButtonColumn("Reject", "danger", (cell) => {
+      const user = cell.row.original;
+      mutation.mutate({ id: user.id, approved: false });
+    }),
+  ];
+
+  return <OurTable data={users} columns={columns} testid={testid} />;
+}

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -68,6 +68,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/moderate">
                     Moderate
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/alias-approval">
+                    Alias Approval
+                  </Nav.Link>
                 </>
               )}
               {currentUser && currentUser.loggedIn ? (

--- a/frontend/src/main/pages/AliasApprovalPage.js
+++ b/frontend/src/main/pages/AliasApprovalPage.js
@@ -1,0 +1,19 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import AliasApprovalTable from "main/components/AliasApprovalTable";
+import { useBackend } from "main/utils/useBackend";
+
+export default function AliasApprovalPage() {
+  const { data: users } = useBackend(
+    ["/api/admin/usersWithProposedAlias"],
+    { method: "GET", url: "/api/admin/usersWithProposedAlias" },
+    [],
+  );
+
+  return (
+    <BasicLayout>
+      <h1>Alias Approval</h1>
+      <AliasApprovalTable users={users} />
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/components/AliasApprovalTable.test.js
+++ b/frontend/src/tests/components/AliasApprovalTable.test.js
@@ -466,31 +466,29 @@ describe("AliasApprovalTable tests", () => {
   });
 
   test("OurTable receives non-empty testid prop", () => {
-    const originalOurTable = jest.requireActual(
-      "main/components/OurTable",
-    ).default;
-    const ourTableSpy = jest.fn((props) => {
-      expect(props.testid).toBeTruthy();
-      expect(props.testid).not.toBe("");
-      expect(props.testid).toBe("AliasApprovalTable");
-
-      return originalOurTable(props);
-    });
-
-    const OurTableModule = require("main/components/OurTable");
-    const originalOurTableRef = OurTableModule.default;
-    OurTableModule.default = ourTableSpy;
-
-    try {
-      renderComponent();
-
-      expect(ourTableSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          testid: "AliasApprovalTable",
-        }),
-      );
-    } finally {
-      OurTableModule.default = originalOurTableRef;
-    }
+  const originalOurTable = jest.requireActual("main/components/OurTable").default;
+  const ourTableSpy = jest.fn((props) => {
+    expect(props.testid).toBeTruthy();
+    expect(props.testid).not.toBe("");
+    expect(props.testid).toBe("AliasApprovalTable");
+    
+    return originalOurTable(props);
   });
+
+  const OurTableModule = require("main/components/OurTable");
+  const originalOurTableRef = OurTableModule.default;
+  OurTableModule.default = ourTableSpy;
+
+  try {
+    renderComponent();
+    
+    expect(ourTableSpy).toHaveBeenCalled();
+    
+    const callArgs = ourTableSpy.mock.calls[0][0];
+    expect(callArgs.testid).toBe("AliasApprovalTable");
+    
+  } finally {
+    OurTableModule.default = originalOurTableRef;
+  }
+});
 });

--- a/frontend/src/tests/components/AliasApprovalTable.test.js
+++ b/frontend/src/tests/components/AliasApprovalTable.test.js
@@ -464,4 +464,33 @@ describe("AliasApprovalTable tests", () => {
       OurTableModule.ButtonColumn = originalButtonColumn;
     }
   });
+
+  test("OurTable receives non-empty testid prop", () => {
+    const originalOurTable = jest.requireActual(
+      "main/components/OurTable",
+    ).default;
+    const ourTableSpy = jest.fn((props) => {
+      expect(props.testid).toBeTruthy();
+      expect(props.testid).not.toBe("");
+      expect(props.testid).toBe("AliasApprovalTable");
+
+      return originalOurTable(props);
+    });
+
+    const OurTableModule = require("main/components/OurTable");
+    const originalOurTableRef = OurTableModule.default;
+    OurTableModule.default = ourTableSpy;
+
+    try {
+      renderComponent();
+
+      expect(ourTableSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          testid: "AliasApprovalTable",
+        }),
+      );
+    } finally {
+      OurTableModule.default = originalOurTableRef;
+    }
+  });
 });

--- a/frontend/src/tests/components/AliasApprovalTable.test.js
+++ b/frontend/src/tests/components/AliasApprovalTable.test.js
@@ -1,0 +1,306 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import AliasApprovalTable from "main/components/AliasApprovalTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { ToastContainer } from "react-toastify";
+
+jest.mock("main/utils/useBackend");
+jest.mock("react-toastify");
+
+describe("AliasApprovalTable tests", () => {
+  let queryClient;
+
+  const sampleUsers = [
+    { id: 1, alias: "OldAlias", proposedAlias: "NewAlias" },
+    { id: 2, alias: "CoolGuy", proposedAlias: "ChillDude" },
+  ];
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    queryClient.invalidateQueries = jest.fn();
+
+    const { useBackendMutation } = require("main/utils/useBackend");
+    const { toast } = require("react-toastify");
+
+    const mockMutate = jest.fn();
+    mockMutate.mockImplementation((variables) => {
+      let returnedUser;
+      if (variables.id === 1 && variables.approved) {
+        returnedUser = { id: 1, alias: "NewAlias", proposedAlias: null };
+      } else if (variables.id === 1 && !variables.approved) {
+        returnedUser = { id: 1, alias: "OldAlias", proposedAlias: null };
+      } else if (variables.id === 2 && variables.approved) {
+        returnedUser = { id: 2, alias: "ChillDude", proposedAlias: null };
+      } else if (variables.id === 2 && !variables.approved) {
+        returnedUser = { id: 2, alias: "CoolGuy", proposedAlias: null };
+      }
+
+      if (returnedUser) {
+        toast(
+          `${variables.approved ? "Approved" : "Rejected"} alias: ${returnedUser.alias}`,
+        );
+        queryClient.invalidateQueries("alias-approval");
+      }
+    });
+
+    useBackendMutation.mockReturnValue({
+      mutate: mockMutate,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function renderComponent() {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <ToastContainer />
+        <AliasApprovalTable users={sampleUsers} />
+      </QueryClientProvider>,
+    );
+  }
+
+  test("renders table with aliases", () => {
+    renderComponent();
+
+    expect(screen.getByText("OldAlias")).toBeInTheDocument();
+    expect(screen.getByText("NewAlias")).toBeInTheDocument();
+    expect(screen.getByText("CoolGuy")).toBeInTheDocument();
+    expect(screen.getByText("ChillDude")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Approve" })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "Reject" })).toHaveLength(2);
+
+    expect(
+      screen.getByTestId("AliasApprovalTable-header-group-0"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("AliasApprovalTable-header-alias"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("AliasApprovalTable-row-0")).toBeInTheDocument();
+  });
+
+  test("approve button triggers mutation for first user", () => {
+    const { toast } = require("react-toastify");
+    const { useBackendMutation } = require("main/utils/useBackend");
+
+    renderComponent();
+
+    const approveButtons = screen.getAllByRole("button", { name: "Approve" });
+    fireEvent.click(approveButtons[0]);
+
+    const mockMutate = useBackendMutation().mutate;
+    expect(mockMutate).toHaveBeenCalledWith({ id: 1, approved: true });
+    expect(toast).toHaveBeenCalledWith("Approved alias: NewAlias");
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(
+      "alias-approval",
+    );
+  });
+
+  test("reject button triggers mutation for first user", () => {
+    const { toast } = require("react-toastify");
+    const { useBackendMutation } = require("main/utils/useBackend");
+
+    renderComponent();
+
+    const rejectButtons = screen.getAllByRole("button", { name: "Reject" });
+    fireEvent.click(rejectButtons[0]);
+
+    const mockMutate = useBackendMutation().mutate;
+    expect(mockMutate).toHaveBeenCalledWith({ id: 1, approved: false });
+    expect(toast).toHaveBeenCalledWith("Rejected alias: OldAlias");
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(
+      "alias-approval",
+    );
+  });
+
+  test("approve button triggers mutation for second user", () => {
+    const { toast } = require("react-toastify");
+    const { useBackendMutation } = require("main/utils/useBackend");
+
+    renderComponent();
+
+    const approveButtons = screen.getAllByRole("button", { name: "Approve" });
+    fireEvent.click(approveButtons[1]);
+
+    const mockMutate = useBackendMutation().mutate;
+    expect(mockMutate).toHaveBeenCalledWith({ id: 2, approved: true });
+    expect(toast).toHaveBeenCalledWith("Approved alias: ChillDude");
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(
+      "alias-approval",
+    );
+  });
+
+  test("reject button triggers mutation for second user", () => {
+    const { toast } = require("react-toastify");
+    const { useBackendMutation } = require("main/utils/useBackend");
+
+    renderComponent();
+
+    const rejectButtons = screen.getAllByRole("button", { name: "Reject" });
+    fireEvent.click(rejectButtons[1]);
+
+    const mockMutate = useBackendMutation().mutate;
+    expect(mockMutate).toHaveBeenCalledWith({ id: 2, approved: false });
+    expect(toast).toHaveBeenCalledWith("Rejected alias: CoolGuy");
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(
+      "alias-approval",
+    );
+  });
+
+  test("handles missing variables in objectToAxiosParams", () => {
+    const { useBackendMutation } = require("main/utils/useBackend");
+    renderComponent();
+
+    const objectToAxiosParams = useBackendMutation.mock.calls[0][0];
+
+    const result1 = objectToAxiosParams();
+    expect(result1).toEqual({});
+
+    const result2 = objectToAxiosParams({ approved: true });
+    expect(result2).toEqual({});
+
+    const result3 = objectToAxiosParams({ id: 1 });
+    expect(result3).toEqual({});
+  });
+
+  test("renders with empty users array", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ToastContainer />
+        <AliasApprovalTable users={[]} />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryAllByRole("button", { name: "Approve" })).toHaveLength(
+      0,
+    );
+    expect(screen.queryAllByRole("button", { name: "Reject" })).toHaveLength(0);
+  });
+
+  test("objectToAxiosParams returns correct object structure", () => {
+    const { useBackendMutation } = require("main/utils/useBackend");
+    renderComponent();
+
+    const objectToAxiosParams = useBackendMutation.mock.calls[0][0];
+    const result = objectToAxiosParams({ id: 1, approved: true });
+
+    expect(result.url).toBe("/api/currentUser/updateAliasModeration");
+    expect(result.method).toBe("PUT");
+    expect(result.params.id).toBe(1);
+    expect(result.params.approved).toBe(true);
+  });
+
+  test("onSuccess callback handles both approved and rejected cases", () => {
+    const { toast } = require("react-toastify");
+    const { useBackendMutation } = require("main/utils/useBackend");
+    renderComponent();
+
+    const onSuccess = useBackendMutation.mock.calls[0][1].onSuccess;
+
+    onSuccess({ alias: "TestApproved" }, { approved: true });
+    expect(toast).toHaveBeenCalledWith("Approved alias: TestApproved");
+
+    onSuccess({ alias: "TestRejected" }, { approved: false });
+    expect(toast).toHaveBeenCalledWith("Rejected alias: TestRejected");
+  });
+
+  test("table headers are rendered correctly", () => {
+    renderComponent();
+
+    expect(
+      screen.getByRole("columnheader", { name: "Alias" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Proposed Alias" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Approve" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Reject" }),
+    ).toBeInTheDocument();
+  });
+
+  test("component renders table correctly", () => {
+    renderComponent();
+    const table = screen.getByRole("table");
+    expect(table).toBeInTheDocument();
+  });
+
+  test("useBackendMutation dependency array is correct", () => {
+    const { useBackendMutation } = require("main/utils/useBackend");
+    renderComponent();
+
+    const deps = useBackendMutation.mock.calls[0][2];
+    expect(deps).toEqual(["alias-approval"]);
+  });
+
+  test("invalidateQueries is called with correct key", () => {
+    renderComponent();
+
+    const approveButtons = screen.getAllByRole("button", { name: "Approve" });
+    fireEvent.click(approveButtons[0]);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(
+      "alias-approval",
+    );
+  });
+
+  test("console.error is called with correct message for missing variables", () => {
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { useBackendMutation } = require("main/utils/useBackend");
+    renderComponent();
+
+    const objectToAxiosParams = useBackendMutation.mock.calls[0][0];
+    objectToAxiosParams();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Missing id or approved in mutation variables:",
+      undefined,
+    );
+    consoleSpy.mockRestore();
+  });
+
+  test("component uses correct testid", () => {
+    const { useBackendMutation } = require("main/utils/useBackend");
+
+    renderComponent();
+
+    expect(useBackendMutation).toHaveBeenCalled();
+
+    const table = screen.getByRole("table");
+    expect(table).toBeInTheDocument();
+  });
+
+  test("queryClient invalidateQueries uses correct cache key", () => {
+    const { useBackendMutation } = require("main/utils/useBackend");
+    renderComponent();
+
+    const onSuccess = useBackendMutation.mock.calls[0][1].onSuccess;
+
+    onSuccess({ alias: "TestAlias" }, { approved: true });
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(
+      "alias-approval",
+    );
+    expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith("");
+  });
+
+  test("button columns have correct styling classes", () => {
+    renderComponent();
+    const approveButtons = screen.getAllByRole("button", { name: "Approve" });
+    const rejectButtons = screen.getAllByRole("button", { name: "Reject" });
+
+    expect(approveButtons[0]).toHaveClass("btn-success");
+    expect(rejectButtons[0]).toHaveClass("btn-danger");
+  });
+});

--- a/frontend/src/tests/components/AliasApprovalTable.test.js
+++ b/frontend/src/tests/components/AliasApprovalTable.test.js
@@ -466,29 +466,30 @@ describe("AliasApprovalTable tests", () => {
   });
 
   test("OurTable receives non-empty testid prop", () => {
-  const originalOurTable = jest.requireActual("main/components/OurTable").default;
-  const ourTableSpy = jest.fn((props) => {
-    expect(props.testid).toBeTruthy();
-    expect(props.testid).not.toBe("");
-    expect(props.testid).toBe("AliasApprovalTable");
-    
-    return originalOurTable(props);
+    const originalOurTable = jest.requireActual(
+      "main/components/OurTable",
+    ).default;
+    const ourTableSpy = jest.fn((props) => {
+      expect(props.testid).toBeTruthy();
+      expect(props.testid).not.toBe("");
+      expect(props.testid).toBe("AliasApprovalTable");
+
+      return originalOurTable(props);
+    });
+
+    const OurTableModule = require("main/components/OurTable");
+    const originalOurTableRef = OurTableModule.default;
+    OurTableModule.default = ourTableSpy;
+
+    try {
+      renderComponent();
+
+      expect(ourTableSpy).toHaveBeenCalled();
+
+      const callArgs = ourTableSpy.mock.calls[0][0];
+      expect(callArgs.testid).toBe("AliasApprovalTable");
+    } finally {
+      OurTableModule.default = originalOurTableRef;
+    }
   });
-
-  const OurTableModule = require("main/components/OurTable");
-  const originalOurTableRef = OurTableModule.default;
-  OurTableModule.default = ourTableSpy;
-
-  try {
-    renderComponent();
-    
-    expect(ourTableSpy).toHaveBeenCalled();
-    
-    const callArgs = ourTableSpy.mock.calls[0][0];
-    expect(callArgs.testid).toBe("AliasApprovalTable");
-    
-  } finally {
-    OurTableModule.default = originalOurTableRef;
-  }
-});
 });

--- a/frontend/src/tests/pages/AliasApprovalPage.test.js
+++ b/frontend/src/tests/pages/AliasApprovalPage.test.js
@@ -1,0 +1,134 @@
+import { render, screen } from "@testing-library/react";
+import AliasApprovalPage from "main/pages/AliasApprovalPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+jest.mock("main/utils/useBackend");
+jest.mock("react-toastify");
+
+describe("AliasApprovalPage tests", () => {
+  let queryClient;
+
+  const mockUsers = [
+    { id: 1, alias: "OldAlias", proposedAlias: "NewAlias" },
+    { id: 2, alias: "CoolGuy", proposedAlias: "ChillDude" },
+  ];
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    const { useBackend, useBackendMutation } = require("main/utils/useBackend");
+
+    useBackend.mockReturnValue({
+      data: mockUsers,
+      isLoading: false,
+      error: null,
+    });
+
+    useBackendMutation.mockReturnValue({
+      mutate: jest.fn(),
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function renderComponent() {
+    return render(
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <AliasApprovalPage />
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+  }
+
+  test("renders page title", () => {
+    renderComponent();
+    expect(screen.getByText("Alias Approval")).toBeInTheDocument();
+  });
+
+  test("renders table with users data", () => {
+    renderComponent();
+    expect(screen.getByText("OldAlias")).toBeInTheDocument();
+    expect(screen.getByText("NewAlias")).toBeInTheDocument();
+    expect(screen.getByText("CoolGuy")).toBeInTheDocument();
+    expect(screen.getByText("ChillDude")).toBeInTheDocument();
+  });
+
+  test("renders approve and reject buttons", () => {
+    renderComponent();
+    expect(screen.getAllByRole("button", { name: "Approve" })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "Reject" })).toHaveLength(2);
+  });
+
+  test("handles empty users data", () => {
+    const { useBackend } = require("main/utils/useBackend");
+    useBackend.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+
+    renderComponent();
+    expect(screen.getByText("Alias Approval")).toBeInTheDocument();
+    expect(screen.queryAllByRole("button", { name: "Approve" })).toHaveLength(
+      0,
+    );
+  });
+
+  test("handles loading state", () => {
+    const { useBackend } = require("main/utils/useBackend");
+    useBackend.mockReturnValue({
+      data: [],
+      isLoading: true,
+      error: null,
+    });
+
+    renderComponent();
+    expect(screen.getByText("Alias Approval")).toBeInTheDocument();
+  });
+
+  test("handles error state", () => {
+    const { useBackend } = require("main/utils/useBackend");
+    useBackend.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: new Error("Test error"),
+    });
+
+    renderComponent();
+    expect(screen.getByText("Alias Approval")).toBeInTheDocument();
+  });
+
+  test("useBackend is called with correct parameters", () => {
+    const { useBackend } = require("main/utils/useBackend");
+    renderComponent();
+
+    expect(useBackend).toHaveBeenCalledWith(
+      ["/api/admin/usersWithProposedAlias"],
+      { method: "GET", url: "/api/admin/usersWithProposedAlias" },
+      [],
+    );
+  });
+
+  test("useBackend hook parameters are correct", () => {
+    const { useBackend } = require("main/utils/useBackend");
+    renderComponent();
+
+    const [queryKey, axiosConfig, initialData] = useBackend.mock.calls[0];
+
+    expect(queryKey).toEqual(["/api/admin/usersWithProposedAlias"]);
+    expect(axiosConfig.method).toBe("GET");
+    expect(axiosConfig.url).toBe("/api/admin/usersWithProposedAlias");
+    expect(initialData).toEqual([]);
+  });
+});

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UsersController.java
@@ -7,9 +7,6 @@ import edu.ucsb.cs156.dining.statuses.ModerationStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.dining.entities.User;
 import edu.ucsb.cs156.dining.repositories.UserRepository;
@@ -49,7 +46,7 @@ public class UsersController extends ApiController {
      * @throws JsonProcessingException if there is an error processing the JSON
      */
     @Operation(summary= "Get a list of all users")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_MODERATOR')")
     @GetMapping("/admin/users")
     public ResponseEntity<String> users()
             throws JsonProcessingException {
@@ -66,7 +63,7 @@ public class UsersController extends ApiController {
      * @throws JsonProcessingException if there is an error processing the JSON
      */
     @Operation(summary = "Get a list of all users with a proposed alias")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_MODERATOR')")
     @GetMapping("/admin/usersWithProposedAlias")
     public ResponseEntity<String> getUsersWithProposedAlias()
             throws JsonProcessingException {
@@ -104,7 +101,7 @@ public class UsersController extends ApiController {
      * @param approved the new moderation status 
      * @return the updated user
      */
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_MODERATOR')")
     @PutMapping("/currentUser/updateAliasModeration")
     public User updateAliasModeration(
             @RequestParam long id, 


### PR DESCRIPTION
Closes #15 
Moderators and Admins can now see requests for Alias updates and approve them. Can be tests in swagger with /updatealias
<img width="1064" alt="a" src="https://github.com/user-attachments/assets/b9c3b87e-d3d1-4559-a18b-9cb573b0306d" />
and /updatealiasmoderation
<img width="1096" alt="aa" src="https://github.com/user-attachments/assets/c27989ee-d99d-443c-884c-ab6ff1fa7d8c" />
<img width="1037" alt="aaa" src="https://github.com/user-attachments/assets/fc695dfb-8164-4995-81f4-7f65fc5ec76e" />
Dokku deployment: https://proj-dev-junjiel123.dokku-10.cs.ucsb.edu
log in, and then go to Alias Approval in the navbar